### PR TITLE
Remove usage and mentions of Julia 0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - osx
   - linux
 julia:
-  - 0.3
   - 0.4
   - 0.5
   - nightly

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Example Julia package repo.
 
-[![Example](http://pkg.julialang.org/badges/Example_0.3.svg)](http://pkg.julialang.org/?pkg=Example&ver=0.3)
-[![Example](http://pkg.julialang.org/badges/Example_0.4.svg)](http://pkg.julialang.org/?pkg=Example&ver=0.4)
+[![Example](http://pkg.julialang.org/badges/Example_0.4.svg)](http://pkg.julialang.org/?pkg=Example)
+[![Example](http://pkg.julialang.org/badges/Example_0.5.svg)](http://pkg.julialang.org/?pkg=Example)
 
 Linux: [![Build Status](https://travis-ci.org/JuliaLang/Example.jl.svg?branch=master)](https://travis-ci.org/JuliaLang/Example.jl)
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,4 +3,4 @@
 # The format of the file is that ignore comments and blank lines, each line must have the form "pkg v1 v2..." where the zero or more version numbers in semantic version format [http://semver.org/] determine what intervals of versions of each package are required.
 # If no REQUIRE file is present, it means there are no requirements.
 # See README.md for more details.
-julia 0.3
+julia 0.4

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.3/julia-0.3-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.3/julia-0.3-latest-win64.exe"
   - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 


### PR DESCRIPTION
This PR makes the following changes:
* Remove 0.3 testing from Travis and AppVeyor
* Add 0.5 testing to AppVeyor
* Replace the 0.3 badge in the README with that for 0.5
* Set the Julia lower bound in REQUIRE to 0.4

I figured this would be a good thing to do if we're no longer allowing packages in METADATA with Julia 0.3 as their lower bound.