### PR TITLE
Add a standard gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.jl.cov
+*.jl.*.cov
+*.jl.mem
+.DS_Store


### PR DESCRIPTION
It's the same as the automatically generated .gitignore file, with the addition of .DS_Store, a garbage OS X file that shows up from time to time (I think Finder adds it).