### PR TITLE
Add Codecov and Julia 0.6

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@ Example Julia package repo.
 
 [![Example](http://pkg.julialang.org/badges/Example_0.4.svg)](http://pkg.julialang.org/?pkg=Example)
 [![Example](http://pkg.julialang.org/badges/Example_0.5.svg)](http://pkg.julialang.org/?pkg=Example)
+[![Example](http://pkg.julialang.org/badges/Example_0.6.svg)](http://pkg.julialang.org/?pkg=Example)
 
 Linux: [![Build Status](https://travis-ci.org/JuliaLang/Example.jl.svg?branch=master)](https://travis-ci.org/JuliaLang/Example.jl)
 
 Windows: [![Build Status](https://ci.appveyor.com/api/projects/status/github/JuliaLang/Example.jl?branch=master&svg=true)](https://ci.appveyor.com/project/tkelman/example-jl/branch/master)
 
 [![Coverage Status](https://coveralls.io/repos/JuliaLang/Example.jl/badge.svg?branch=master)](https://coveralls.io/r/JuliaLang/Example.jl?branch=master)
-
+[![codecov.io](http://codecov.io/github/JuliaLang/Example.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaLang/Example.jl?branch=master)


### PR DESCRIPTION
Codecov seems to be gaining popularity, so I figured it might be a good idea to add it to the example package. I've included a configuration YAML that turns off PR comments. If you want Codecov to work on this repo, a JuliaLang owner (I think) will have to enable it.

I've also added the Julia 0.6 badge to the README.