### PR TITLE
Remove deprecated -F option

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ install:
 build_script:
 # Need to convert from shallow to complete for Pkg.clone to work
   - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -F -e "versioninfo();
+  - C:\projects\julia\bin\julia -e "versioninfo();
       Pkg.clone(pwd(), \"Example\"); Pkg.build(\"Example\")"
 
 test_script:


### PR DESCRIPTION
Fixes the AppVeyor build on Julia 0.6.