### PR TITLE
Update example .travis.yml w/ built-in coveralls config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ os:
   - linux
 julia:
   - 0.6
-  - 0.7
   - nightly
 notifications:
   email: false
-#script: # the default script is equivalent to the following
+coveralls: true
+# codecov: true  # Enable one of these depending on which coverage service you use.
+
+# Note, the default script is equivalent to the following:
+#script: 
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("Example"); Pkg.test("Example"; coverage=true)';
-after_success:
-  - julia -e 'cd(Pkg.dir("Example")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
-#  - julia -e 'cd(Pkg.dir("Example")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())';
+#  - julia -e 'if (VERSION >= v"0.7.0-") using Pkg; end; Pkg.clone(pwd()); Pkg.build("Example"); Pkg.test("Example"; coverage=true)';


### PR DESCRIPTION
After https://github.com/travis-ci/travis-build/pull/1450, repo's Travis config should be using the built-in options for `coveralls` and `codecov`, rather than manually adding those to `after_success`.