### PR TITLE
Use OSI standard license text

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,22 +1,7 @@
-The Example.jl package is licensed under the MIT "Expat" License:
+Copyright 2013 Stefan Karpinski, Iain Dunning, and other contributors.
 
-> Copyright (c) 2013-2014: Stefan Karpinski, Iain Dunning, _et al._
->
-> Permission is hereby granted, free of charge, to any person obtaining
-> a copy of this software and associated documentation files (the
-> "Software"), to deal in the Software without restriction, including
-> without limitation the rights to use, copy, modify, merge, publish,
-> distribute, sublicense, and/or sell copies of the Software, and to
-> permit persons to whom the Software is furnished to do so, subject to
-> the following conditions:
->
-> The above copyright notice and this permission notice shall be
-> included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-> EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-> MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-> IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-> CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-> TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-> SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 Example Julia package repo.
 
+[![License: MIT - Permissive License](https://img.shields.io/badge/License-MIT-blue.svg)](https://img.shields.io/github/license/JuliaLang/Example.jl)
+
 [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaLang.github.io/Example.jl/stable)
 [![](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaLang.github.io/Example.jl/dev)
 


### PR DESCRIPTION
People usually use or used Pkg.jl, PkgDev.jl or PkgTemplates to develop a new package. A common feature is to include by default a `LICENSE.md` file. This is great. By default most packages would opt into the [MIT License (Expat)](https://tldrlegal.com/license/mit-license) license with additional metadata (e.g., package name) included and some markdown prettifier (`> License text as a quote`). However, there are two issues I would like to bring:
1. If we choose to keep the current behavior and default to an MIT family license which one should it default to?
    - I personally think ISC is a good choice since it just simplifies the text with the latest legal framework.
2. Should we keep the metadata and markdown features?
    - Here my strong opinion is that we should be using the OSI standard license text. The biggest issue in my opinion is that the current approach is not machine detectable which makes most of the great Julia ecosystem invisible in terms of open source projects (e.g., at least for programmatically analysis such as for the purpose of GitHub and services that rely on it).