### PR TITLE
Update the Documenter version

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,4 +2,4 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "0.23"
+Documenter = "0.25.1"


### PR DESCRIPTION
For me, Documenter.jl version `0.23` was unable to generate the documentation after I copied this project. It did work after updating to `0.24.10`. This pull request proposes the newest version of Documenter.jl, that is, `0.25.1`.