### PR TITLE
CI: Add quotes around versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 1.0
-          - 1 # automatically expands to the latest stable 1.x release of Julia
+          - '1.0'
+          - '1' # automatically expands to the latest stable 1.x release of Julia
           - nightly
         os:
           - ubuntu-latest


### PR DESCRIPTION
The yaml parser used by GitHub can't tell apart `1` and `1.0` if they're numbers, so they'll point at the same version. Wrapping them in quotes gets around that.