### PR TITLE
Rename default branch from master => main in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags: ["*"]
   pull_request:
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [main]
+    branches: [main, master]
     tags: ["*"]
   pull_request:
 jobs:


### PR DESCRIPTION
Since everyone usually has this set up with `main` as the default branch these days.

Or should I maybe add both instead?